### PR TITLE
solved both issues

### DIFF
--- a/Gatsby-JS-Templates/dev-jedi/package.json
+++ b/Gatsby-JS-Templates/dev-jedi/package.json
@@ -14,7 +14,7 @@
     "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing\" && exit 1"
   },
   "dependencies": {
-    "gatsby": "^4.9.0",
+    "gatsby": "^5.7.0",
     "gatsby-plugin-image": "^2.9.1",
     "gatsby-plugin-sharp": "^4.9.1",
     "gatsby-source-filesystem": "^4.9.0",

--- a/Vanilla Templates/Grid-Layout-Portfolio/index.html
+++ b/Vanilla Templates/Grid-Layout-Portfolio/index.html
@@ -36,6 +36,14 @@
       </div>
       <img src="assets/scape.png" alt="landscape pic">
     </div>
+    <div class="grid-container">
+      <div class="grid-item">Item 1</div>
+      <div class="grid-item">Item 2</div>
+      <div class="grid-item">Item 3</div>
+      <div class="grid-item">Item 4</div>
+      <div class="grid-item">Item 5</div>
+      <div class="grid-item">Item 6</div>
+    </div>
   </main>
 </body>
 </html>

--- a/Vanilla Templates/Grid-Layout-Portfolio/style.css
+++ b/Vanilla Templates/Grid-Layout-Portfolio/style.css
@@ -73,3 +73,36 @@ main {
     min-width: 100%;
     min-height: 100%;
 }
+/* Set the container to display as a grid */
+.grid-container {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr); /* Three columns */
+  grid-gap: 20px;
+}
+
+/* Set the grid items to span the full width of the container */
+.grid-item {
+  grid-column: span 3;
+}
+
+/* Media query for screens smaller than 768px */
+@media screen and (max-width: 768px) {
+  .grid-container {
+    grid-template-columns: repeat(2, 1fr); /* Two columns */
+  }
+
+  .grid-item {
+    grid-column: span 2;
+  }
+}
+
+/* Media query for screens smaller than 480px */
+@media screen and (max-width: 480px) {
+  .grid-container {
+    grid-template-columns: 1fr; /* One column */
+  }
+
+  .grid-item {
+    grid-column: span 1;
+  }
+}


### PR DESCRIPTION
Update dev-jedi template with current Gatsby version ---Used 5.7.0 version

Add Responsiveness to Grid Layout Portfolio---
The grid container has three columns by default. When the screen size is smaller than 768px, the container changes to two columns, and when the screen size is smaller than 480px, the container changes to a single column.

You can adjust the media queries to fit your specific needs and the number of columns in your grid.